### PR TITLE
Hash the user+key for the cache key

### DIFF
--- a/lrukeystore.go
+++ b/lrukeystore.go
@@ -44,7 +44,7 @@ func New(size int) (*KeyStore, error) {
 
 }
 
-func (ks *KeyStore) deriveKey(user, key string) []byte {
+func (ks *KeyStore) deriveHash(user, key string) []byte {
 	mac := hmac.New(sha256.New, ks.systemKey)
 	mac.Write([]byte(user))
 	mac.Write([]byte(key))
@@ -54,7 +54,7 @@ func (ks *KeyStore) deriveKey(user, key string) []byte {
 // IsIn checks to see if user has the putative key in the KeyStore
 func (ks *KeyStore) IsIn(user, putative string) bool {
 
-	computedMAC := ks.deriveKey(user, putative)
+	computedMAC := ks.deriveHash(user, putative)
 
 	val, ok := ks.cache.Get(user)
 	if !ok {
@@ -68,7 +68,7 @@ func (ks *KeyStore) IsIn(user, putative string) bool {
 
 // Add adds a new key to the KeyStore using the internal hashing scheme
 func (ks *KeyStore) Add(user, key string) {
-	expectedMAC := ks.deriveKey(user, key)
+	expectedMAC := ks.deriveHash(user, key)
 
 	ks.cache.Add(user, expectedMAC)
 }

--- a/lrukeystore.go
+++ b/lrukeystore.go
@@ -47,6 +47,7 @@ func New(size int) (*KeyStore, error) {
 // IsIn checks to see if user has the putative key in the KeyStore
 func (ks *KeyStore) IsIn(user string, putative string) bool {
 	mac := hmac.New(sha256.New, ks.systemKey)
+	mac.Write([]byte(user))
 	mac.Write([]byte(putative))
 	computedMAC := mac.Sum(nil)
 
@@ -63,6 +64,7 @@ func (ks *KeyStore) IsIn(user string, putative string) bool {
 // Add adds a new key to the KeyStore using the internal hashing scheme
 func (ks *KeyStore) Add(user string, key string) {
 	mac := hmac.New(sha256.New, ks.systemKey)
+	mac.Write([]byte(user))
 	mac.Write([]byte(key))
 	expectedMAC := mac.Sum(nil)
 

--- a/lrukeystore.go
+++ b/lrukeystore.go
@@ -56,19 +56,14 @@ func (ks *KeyStore) IsIn(user, putative string) bool {
 
 	computedMAC := ks.deriveHash(user, putative)
 
-	val, ok := ks.cache.Get(user)
-	if !ok {
-		return false
-	}
+	_, ok := ks.cache.Get(string(computedMAC))
 
-	expectedMAC := val.([]byte)
-
-	return hmac.Equal(expectedMAC, computedMAC)
+	return ok
 }
 
 // Add adds a new key to the KeyStore using the internal hashing scheme
 func (ks *KeyStore) Add(user, key string) {
 	expectedMAC := ks.deriveHash(user, key)
 
-	ks.cache.Add(user, expectedMAC)
+	ks.cache.Add(string(expectedMAC), true)
 }


### PR DESCRIPTION
Now it's just an existence check, as suggested by @smashwilson. If anyone got access to the key store in memory, this prevents them from getting the list of users.

However, it disables our ability to revoke individual user accounts. I'm kind of :-1: on my own PR here.
